### PR TITLE
Fix visual tree root discovery.

### DIFF
--- a/Winium/TestApp.Test/Samples/AutoSuggestSample.cs
+++ b/Winium/TestApp.Test/Samples/AutoSuggestSample.cs
@@ -39,7 +39,7 @@
 
             var basePath = Directory.GetCurrentDirectory();
             const string FilePath =
-                "..\\..\\..\\..\\TestApp\\TestApp.WindowsPhone\\AppPackages\\TestApp.WindowsPhone_1.0.0.0_AnyCPU_Test\\TestApp.WindowsPhone_1.0.0.0_AnyCPU.appx";
+                "..\\..\\..\\..\\TestApp\\TestApp.WindowsPhone\\AppPackages\\TestApp.WindowsPhone_1.0.0.0_AnyCPU_Debug_Test\\TestApp.WindowsPhone_1.0.0.0_AnyCPU_Debug.appx";
             var autPath = Path.GetFullPath(Path.Combine(basePath, FilePath));
 
             capabillities.SetCapability("app", autPath);
@@ -86,18 +86,7 @@
                     continue;
                 }
 
-                /* Unfortunatly when some inputs, including AutoSuggestBox are focused
-                 * whole interface is scrolled up, but driver still returns original coordinates
-                 * automation: GetClickablePoint is a temporary solution for this problem,
-                 * in this case it returns correct coordinates
-                */
-                var coords = this.driver.ExecuteScript("automation: GetClickablePoint", suggest).ToString().Split(',');
-
-                // Execute script returns string, so now we will have to parse it
-                var x = float.Parse(coords[0], CultureInfo.InvariantCulture.NumberFormat);
-                var y = float.Parse(coords[1], CultureInfo.InvariantCulture.NumberFormat);
-                var ac = new Actions(this.driver);
-                ac.MoveByOffset((int)x, (int)y).Click().Perform();
+                suggest.Click();
 
                 break;
             }

--- a/Winium/TestApp.Test/py-functional/tests/test_commands.py
+++ b/Winium/TestApp.Test/py-functional/tests/test_commands.py
@@ -46,8 +46,8 @@ class TestGetCommands(WuaTestCase):
         source = self.driver.page_source
         root = ElementTree.fromstring(source.encode('utf-8'))
         visual_root = next(root.iterfind('*'))
-        assert 'Windows.UI.Xaml.Controls.Frame' == visual_root.tag
-        assert sum(1 for _ in root.iterfind('*')) == 2, 'Page source should contain at both visual root and popups'
+        assert 'Windows.UI.Xaml.Controls.ScrollViewer' == visual_root.tag
+        assert sum(1 for _ in root.iterfind('*')) > 1, 'Page source should contain at both visual root and popups'
         assert any(visual_root.iterfind('*')), 'Page source should contain at least one children of visual root'
 
     @pytest.mark.parametrize(("by", "value"), [
@@ -284,12 +284,7 @@ class TestAutoSuggestBox(WuaTestCase):
 
         for suggest in suggestions:
             if suggest.text == expected_text:
-                # When AutoSuggest is focused it moves whole view up
-                # but it is not reflected coordinates that we get from driver,
-                # instead of suggest.click() we will have to use Select pattern
-                point = self.driver.execute_script('automation: GetClickablePoint', suggest)
-                x, y = [float(v) for v in point.split(',')]
-                ActionChains(self.driver).move_by_offset(x, y).click().perform()
+                suggest.click()
                 break
 
         assert expected_text == autosuggestion_input.text

--- a/Winium/Winium.StoreApps.InnerServer/Automator.cs
+++ b/Winium/Winium.StoreApps.InnerServer/Automator.cs
@@ -10,6 +10,7 @@
     using Newtonsoft.Json.Linq;
 
     using Windows.UI.Xaml;
+    using Windows.UI.Xaml.Media;
 
     using Winium.StoreApps.Common;
     using Winium.StoreApps.InnerServer.Commands;
@@ -22,7 +23,7 @@
 
         public Automator(UIElement visualRoot)
         {
-            this.VisualRoot = visualRoot;
+            this.VisualRoot = GetTrueVisualRoot(visualRoot);
             this.WebElements = new AutomatorElements();
         }
 
@@ -148,6 +149,34 @@
             var response = commandToExecute.Do();
 
             return response;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Walk visual tree upwards til we find actual visual root. 
+        /// This fixes incorrect locations being returned for elements when app screen is scrolled up to make place for onscreen keyboards, etc (issue #34 ).
+        /// </summary>
+        /// <param name="visualRoot">
+        /// </param>
+        /// <returns>
+        /// The <see cref="UIElement"/>.
+        /// </returns>
+        private static UIElement GetTrueVisualRoot(UIElement visualRoot)
+        {
+            var root = visualRoot;
+            while (true)
+            {
+                var parent = VisualTreeHelper.GetParent(root) as UIElement;
+                if (parent == null)
+                {
+                    return root;
+                }
+
+                root = parent;
+            }
         }
 
         #endregion


### PR DESCRIPTION
Fixes #34 incorrect element location being returned if app is scrolled up to make place for on-screen keyboard, etc.