### PR TITLE
Add element size and rect support

### DIFF
--- a/Winium/TestApp.Test/py-functional/tests/test_commands.py
+++ b/Winium/TestApp.Test/py-functional/tests/test_commands.py
@@ -147,6 +147,14 @@ class TestGetCommands(WuaTestCase):
         location = self.driver.find_element_by_id('MyTextBox').location
         assert {'x': 240, 'y': 261} == location
 
+    def test_get_element_size(self):
+        size = self.driver.find_element_by_id('MyTextBox').size
+        assert size == {'height': 120, 'width': 360}
+
+    def test_get_element_rect(self):
+        rect = self.driver.find_element_by_id('MyTextBox').rect
+        assert rect == {'height': 120, 'width': 360, 'x': 60, 'y': 202}
+
     def test_get_orientation(self):
         """
         GET /session/:sessionId/orientation Get the current browser orientation.

--- a/Winium/Winium.StoreApps.Common/DriverCommand.cs
+++ b/Winium/Winium.StoreApps.Common/DriverCommand.cs
@@ -469,6 +469,12 @@ namespace Winium.StoreApps.Common
 
         #endregion
 
+        #region Winium
+
+        public static readonly string GetElementRect = "getElementRect";
+
+        #endregion
+
         #region Appium
 
         public static readonly string LaunchApp = "launchApp";

--- a/Winium/Winium.StoreApps.Driver/EmulatorHelpers/Deployer81.cs
+++ b/Winium/Winium.StoreApps.Driver/EmulatorHelpers/Deployer81.cs
@@ -131,9 +131,9 @@ namespace Winium.StoreApps.Driver.EmulatorHelpers
             this.RemoteApplication.Launch();
         }
 
-        public void ReciveFiles(Dictionary<string, string> files)
+        public void ReceiveFiles(Dictionary<string, string> files)
         {
-            throw new NotImplementedException("Deployer81.ReciveFiles");
+            throw new NotImplementedException("Deployer81.ReceiveFiles");
         }
 
         public void SendFiles(Dictionary<string, string> files)

--- a/Winium/Winium.StoreApps.Driver/EmulatorHelpers/IDeployer.cs
+++ b/Winium/Winium.StoreApps.Driver/EmulatorHelpers/IDeployer.cs
@@ -20,7 +20,7 @@
 
         void Launch();
 
-        void ReciveFiles(Dictionary<string, string> files);
+        void ReceiveFiles(Dictionary<string, string> files);
 
         void SendFiles(Dictionary<string, string> files);
 

--- a/Winium/Winium.StoreApps.Driver/UriDispatchTables.cs
+++ b/Winium/Winium.StoreApps.Driver/UriDispatchTables.cs
@@ -29,6 +29,7 @@
         public UriDispatchTables(Uri prefix)
         {
             this.InitializeSeleniumCommandDictionary();
+            this.InitializeWiniumCommandDictionary();
             this.InitializeAppiumCommandDictionary();
             this.ConstructDispatcherTables(prefix);
         }
@@ -287,6 +288,11 @@
                 DriverCommand.TouchFlick, 
                 new CommandInfo("POST", "/session/{sessionId}/touch/flick"));
             this.commandDictionary.Add(DriverCommand.UploadFile, new CommandInfo("POST", "/session/{sessionId}/file"));
+        }
+
+        private void InitializeWiniumCommandDictionary()
+        {
+            this.commandDictionary.Add(DriverCommand.GetElementRect, new CommandInfo("GET", "/session/{sessionId}/element/{id}/rect"));
         }
 
         private void InitializeAppiumCommandDictionary()

--- a/Winium/Winium.StoreApps.InnerServer/Automator.cs
+++ b/Winium/Winium.StoreApps.InnerServer/Automator.cs
@@ -121,6 +121,14 @@
             {
                 commandToExecute = new LocationInViewCommand { ElementId = elementId };
             }
+            else if (command.Equals(DriverCommand.GetElementSize))
+            {
+                commandToExecute = new GetElementSizeCommand { ElementId = elementId };
+            }
+            else if (command.Equals(DriverCommand.GetElementRect))
+            {
+                commandToExecute = new GetElementRectCommand { ElementId = elementId };
+            }
             else if (command.Equals(DriverCommand.GetPageSource))
             {
                 commandToExecute = new PageSourceCommand { ElementId = elementId };

--- a/Winium/Winium.StoreApps.InnerServer/Commands/GetElementRectCommand.cs
+++ b/Winium/Winium.StoreApps.InnerServer/Commands/GetElementRectCommand.cs
@@ -1,0 +1,39 @@
+﻿﻿namespace Winium.StoreApps.InnerServer.Commands
+ {
+     #region
+
+     using System.Collections.Generic;
+
+     using Winium.StoreApps.Common;
+
+     #endregion
+
+     internal class GetElementRectCommand : CommandBase
+     {
+         #region Public Properties
+
+         public string ElementId { private get; set; }
+
+         #endregion
+
+         #region Public Methods and Operators
+
+         protected override string DoImpl()
+         {
+             // FIXME Replace GetElementSizeCommand and LocationCommand with calls to this command as it is done in FireFox driver
+             var element = this.Automator.ElementsRegistry.GetRegisteredElement(this.ElementId);
+             var rect = element.GetRect();
+             var response = new Dictionary<string, int>
+                                      {
+                                          { "x", (int)rect.X },
+                                          { "y", (int)rect.Y },
+                                          { "width", (int)rect.Width }, 
+                                          { "height", (int)rect.Height }
+                                      };
+
+             return this.JsonResponse(ResponseStatus.Success, response);
+         }
+
+         #endregion
+     }
+ }

--- a/Winium/Winium.StoreApps.InnerServer/Commands/GetElementSizeCommand.cs
+++ b/Winium/Winium.StoreApps.InnerServer/Commands/GetElementSizeCommand.cs
@@ -1,0 +1,36 @@
+﻿﻿namespace Winium.StoreApps.InnerServer.Commands
+ {
+     #region
+
+     using System.Collections.Generic;
+
+     using Winium.StoreApps.Common;
+
+     #endregion
+
+     internal class GetElementSizeCommand : CommandBase
+     {
+         #region Public Properties
+
+         public string ElementId { private get; set; }
+
+         #endregion
+
+         #region Public Methods and Operators
+
+         protected override string DoImpl()
+         {
+             var element = this.Automator.ElementsRegistry.GetRegisteredElement(this.ElementId);
+             var rect = element.GetRect();
+             var response = new Dictionary<string, int>
+                                      {
+                                          { "width", (int)rect.Width }, 
+                                          { "height", (int)rect.Height }
+                                      };
+
+             return this.JsonResponse(ResponseStatus.Success, response);
+         }
+
+         #endregion
+     }
+ }

--- a/Winium/Winium.StoreApps.InnerServer/Winium.StoreApps.InnerServer.csproj
+++ b/Winium/Winium.StoreApps.InnerServer/Winium.StoreApps.InnerServer.csproj
@@ -46,6 +46,8 @@
     <Compile Include="AcceptedRequest.cs" />
     <Compile Include="AutomationServer.cs" />
     <Compile Include="Automator.cs" />
+    <Compile Include="Commands\GetElementRectCommand.cs" />
+    <Compile Include="Commands\GetElementSizeCommand.cs" />
     <Compile Include="ElementsRegistry.cs" />
     <Compile Include="Commands\AlertCommand.cs" />
     <Compile Include="Commands\AlertTextCommand.cs" />


### PR DESCRIPTION
Note:
Python and JavaScript seems to support extended command getElementRect, that is not inlcuded in basic JSWP.

FireFox implements getElementLocation, getElementSize and getElementRect with one getElementRect command. Should we go the same way to reduce code base?

https://github.com/SeleniumHQ/selenium/search?utf8=%E2%9C%93&q=getelementrect