### PR TITLE
Use minute instead of month in logger timestamp.

### DIFF
--- a/Winium/Winium.StoreApps.Driver/Logger.cs
+++ b/Winium/Winium.StoreApps.Driver/Logger.cs
@@ -13,7 +13,7 @@
     {
         #region Constants
 
-        private const string LayoutFormat = "${date:format=HH\\:MM\\:ss} [${level:uppercase=true}] ${message}";
+        private const string LayoutFormat = "${date:format=HH\\:mm\\:ss} [${level:uppercase=true}] ${message}";
 
         #endregion
 


### PR DESCRIPTION
Fixed a tiny bug, where log statements would use the month number as minutes in the timestamp.