### PR TITLE
Use indented formatting for JSON responses. Prettify log

### DIFF
--- a/Winium/Winium.StoreApps.Common/CommandResponse.cs
+++ b/Winium/Winium.StoreApps.Common/CommandResponse.cs
@@ -25,7 +25,7 @@
 
         public override string ToString()
         {
-            return string.Format("{0}: {1}", this.HttpStatusCode, this.Content);
+            return string.Format("{0}:\n{1}", this.HttpStatusCode, this.Content);
         }
 
         #endregion

--- a/Winium/Winium.StoreApps.Driver/CommandExecutors/CommandExecutorBase.cs
+++ b/Winium/Winium.StoreApps.Driver/CommandExecutors/CommandExecutorBase.cs
@@ -50,7 +50,7 @@
             {
                 // Bad status returned by Inner Driver when trying to forward command
                 return CommandResponse.Create(
-                    exception.StatusCode,
+                    exception.StatusCode, 
                     this.JsonResponse(ResponseStatus.UnknownError, exception));
             }
             catch (NotImplementedException exception)
@@ -76,20 +76,11 @@
             throw new InvalidOperationException("DoImpl should never be called in CommandExecutorBase");
         }
 
-        /// <summary>
-        /// The JsonResponse with SUCCESS status and NULL value.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="string"/>.
-        /// </returns>
-        protected string JsonResponse()
+        protected string JsonResponse(ResponseStatus status = ResponseStatus.Success, object value = null)
         {
-            return this.JsonResponse(ResponseStatus.Success, null);
-        }
-
-        protected string JsonResponse(ResponseStatus status, object value)
-        {
-            return JsonConvert.SerializeObject(new JsonResponse(this.Automator.Session, status, value));
+            return JsonConvert.SerializeObject(
+                new JsonResponse(this.Automator.Session, status, value), 
+                Formatting.Indented);
         }
 
         #endregion

--- a/Winium/Winium.StoreApps.Driver/Listener.cs
+++ b/Winium/Winium.StoreApps.Driver/Listener.cs
@@ -172,10 +172,10 @@
             Logger.Info("COMMAND {0}\r\n{1}", command.Name, command.Parameters.ToString());
             var executor = this.executorDispatcher.GetExecutor(command.Name);
             executor.ExecutedCommand = command;
-            var respnose = executor.Do();
-            Logger.Debug("RESPONSE:\r\n{0}", respnose);
+            var response = executor.Do();
+            Logger.Debug("RESPONSE:\r\n{0}", response);
 
-            return respnose;
+            return response;
         }
 
         #endregion

--- a/Winium/Winium.StoreApps.InnerServer/Commands/CommandBase.cs
+++ b/Winium/Winium.StoreApps.InnerServer/Commands/CommandBase.cs
@@ -62,25 +62,14 @@
             throw new NotImplementedException();
         }
 
-        /// <summary>
-        /// The JsonResponse with SUCCESS status and NULL value.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="string"/>.
-        /// </returns>
-        protected string JsonResponse()
-        {
-            return JsonConvert.SerializeObject(new JsonResponse(this.Session, ResponseStatus.Success, null));
-        }
-
-        protected string JsonResponse(ResponseStatus status, object value)
+        protected string JsonResponse(ResponseStatus status = ResponseStatus.Success, object value = null)
         {
             if (status != ResponseStatus.Success && value == null)
             {
                 value = string.Format("WebDriverException {0}", Enum.GetName(typeof(ResponseStatus), status));
             }
 
-            return JsonConvert.SerializeObject(new JsonResponse(this.Session, status, value));
+            return JsonConvert.SerializeObject(new JsonResponse(this.Session, status, value), Formatting.Indented);
         }
 
         private static void InvokeSync(CoreDispatcher dispatcher, Action action)


### PR DESCRIPTION
Use indented formatting for serialization of responses. This results in more human-readable log.