### PR TITLE
Added support for dependencies

### DIFF
--- a/Winium/Winium.StoreApps.Driver/Automator/Automator.cs
+++ b/Winium/Winium.StoreApps.Driver/Automator/Automator.cs
@@ -162,6 +162,7 @@
             this.Deployer = new Deployer(this.ActualCapabilities.DeviceName, strictMatchDeviceName, appPath);
             if (!debugDoNotDeploy)
             {
+                this.Deployer.InstallDependencies(this.ActualCapabilities.Dependencies);
                 this.Deployer.Install();
                 this.Deployer.SendFiles(this.ActualCapabilities.Files);
             }

--- a/Winium/Winium.StoreApps.Driver/Automator/Capabilities.cs
+++ b/Winium/Winium.StoreApps.Driver/Automator/Capabilities.cs
@@ -32,6 +32,7 @@
             this.LaunchTimeout = 10000;
             this.DebugConnectToRunningApp = false;
             this.TakesScreenshot = true;
+            this.Dependencies = new List<string>();
         }
 
         #endregion
@@ -98,6 +99,9 @@
 
         [JsonProperty("takesScreenshot")]
         public bool TakesScreenshot { get; set; }
+
+        [JsonProperty("dependencies")]
+        public List<string> Dependencies { get; set; }
 
         #endregion
 

--- a/Winium/Winium.StoreApps.Driver/CommandLineOptions.cs
+++ b/Winium/Winium.StoreApps.Driver/CommandLineOptions.cs
@@ -33,6 +33,9 @@
         [Option("nodeconfig", Required = false, HelpText = "configuration JSON file to register driver with selenium grid")]
         public string NodeConfig { get; set; }
 
+        [Option("dependency", Required = false, HelpText = "dependencies to be installed before main app")]
+        public string Dependency { get; set; }
+
         #endregion
 
         #region Public Methods and Operators

--- a/Winium/Winium.StoreApps.Driver/CommandLineOptions.cs
+++ b/Winium/Winium.StoreApps.Driver/CommandLineOptions.cs
@@ -33,9 +33,6 @@
         [Option("nodeconfig", Required = false, HelpText = "configuration JSON file to register driver with selenium grid")]
         public string NodeConfig { get; set; }
 
-        [Option("dependency", Required = false, HelpText = "dependencies to be installed before main app")]
-        public string Dependency { get; set; }
-
         #endregion
 
         #region Public Methods and Operators

--- a/Winium/Winium.StoreApps.Driver/EmulatorHelpers/Deployer.cs
+++ b/Winium/Winium.StoreApps.Driver/EmulatorHelpers/Deployer.cs
@@ -155,6 +155,25 @@ namespace Winium.StoreApps.Driver.EmulatorHelpers
             }
         }
 
+        public void InstallDependencies(List<string> dependencies )
+        {
+            if (dependencies == null || !dependencies.Any())
+            {
+                return;
+            }
+
+            foreach (var dependency in dependencies)
+            {
+                InstallDependency(dependency);
+            }
+        }
+
+        public void InstallDependency(string path)
+        {
+            var appManifest = Utils.ReadAppManifestInfoFromPackage(path);
+            Utils.InstallApplication(this.deviceInfo, appManifest, DeploymentOptions.None, path);
+        }
+
         public void Terminate()
         {
             throw new NotImplementedException("Deployer.Terminate");


### PR DESCRIPTION
Ref mail with @NickAb : Here is a pull request on dependencies.

In our app we get a dependency conflict when we try to install it ( `Error - Package failed updates, dependency or conflict validation` ) This happens when we try to install it on a fresh emulator. The solution we found was to first install the dependency `.appx` and then the main `.appx` Here is a pull request on how acheived this using `Winium`

Usage (python): just add `"dependencies":["dep1.appx","dep2.appx", ....]` to your capabilities

