### PR TITLE
Fix debugConnectToRunningApp throwing NullReferenceException

### DIFF
--- a/Winium/Winium.Mobile.Connectivity/Deployer.cs
+++ b/Winium/Winium.Mobile.Connectivity/Deployer.cs
@@ -95,6 +95,12 @@ namespace Winium.Mobile.Connectivity
             this.InstallApp(appPath);
         }
 
+        public void UsePreInstalledApplication(string appPath)
+        {
+            var appManifest = Utils.ReadAppManifestInfoFromPackage(appPath);
+            this.RemoteApplication = this.Device.GetApplication(appManifest.ProductId);
+        }
+
         public void Launch()
         {
             this.Device.Activate();

--- a/Winium/Winium.Mobile.Connectivity/IDeployer.cs
+++ b/Winium/Winium.Mobile.Connectivity/IDeployer.cs
@@ -18,6 +18,8 @@ namespace Winium.Mobile.Connectivity
 
         void Install(string appPath, List<string> dependencies);
 
+        void UsePreInstalledApplication(string appPath);
+
         void Launch();
 
         void ReceiveFile(string isoStoreRoot, string sourceDeviceFilePath, string targetDesktopFilePath);

--- a/Winium/Winium.StoreApps.Driver/CommandExecutors/NewSessionExecutor.cs
+++ b/Winium/Winium.StoreApps.Driver/CommandExecutors/NewSessionExecutor.cs
@@ -28,12 +28,8 @@
                     JsonConvert.SerializeObject(this.ExecutedCommand.Parameters["desiredCapabilities"]);
                 this.Automator.ActualCapabilities = Capabilities.CapabilitiesFromJsonString(serializedCapability);
 
-                this.Automator.InitializeApp();
-                if (this.Automator.ActualCapabilities.AutoLaunch)
-                {
-                    this.Automator.Deployer.Launch();
-                    this.Automator.ConnectToApp();
-                }
+                this.Automator.Deploy();
+                
 
                 return this.JsonResponse(ResponseStatus.Success, this.Automator.ActualCapabilities);
             }


### PR DESCRIPTION
Wiki needs an update for debugConnectToRunningApp capability:
`debugConnectToRunningApp` now requires `app` capability to be set.
`ProductId` will be read from app manifest inside `app` package.
This `ProductId` will used to locate and launch app on device.
If `AutoLaunch` is set to True, then app will be launched, regardles of
`debugConnectToRunningApp` or app already being launched,
this might have side effects.