### PR TITLE
Change the way GetElementAttribute handles attribute names

### DIFF
--- a/Winium/TestApp.Test/py-functional/tests/test_commands.py
+++ b/Winium/TestApp.Test/py-functional/tests/test_commands.py
@@ -109,7 +109,7 @@ class TestGetCommands(WuaTestCase):
     @pytest.mark.parametrize(("attr_name", "expected_value"), [
         ('Width', '300'),
         ('DesiredSize.Width', '300'),
-        ('AutomationIdProperty', 'MyTextBox'),
+        ('AutomationProperties.AutomationId', 'MyTextBox'),
         ('Visibility', '0'),
     ], ids=['simple property', 'nested property', 'automation property', 'enum'])
     def test_get_element_attribute(self, attr_name, expected_value):

--- a/Winium/TestApp.Test/py-functional/tests/test_element_attribute_settings.py
+++ b/Winium/TestApp.Test/py-functional/tests/test_element_attribute_settings.py
@@ -55,6 +55,6 @@ class TestElementAttributeCommandSettings(object):
 
         element = driver.find_element_by_id('MyTextBox')
 
-        for i, attr in enumerate(['AutomationIdProperty', 'IsReadOnlyProperty', 'Width']):
+        for i, attr in enumerate(['AutomationProperties.AutomationId', 'IsReadOnly', 'Width']):
             value = element.get_attribute(attr)
             assert expected[i] == value

--- a/Winium/Winium.StoreApps.InnerServer/Element/Helpers/AutomationPropertiesAccessor.cs
+++ b/Winium/Winium.StoreApps.InnerServer/Element/Helpers/AutomationPropertiesAccessor.cs
@@ -12,8 +12,10 @@
 
         public static bool TryGetAutomationProperty(FrameworkElement element, string propertyName, out object value)
         {
+            propertyName = string.Format("{0}Property", propertyName);
             value = null;
             DependencyProperty property;
+
             if (!AutomationPropertiesHelper.Instance.TryGetAutomationProperty(propertyName, out property))
             {
                 return false;

--- a/Winium/Winium.StoreApps.InnerServer/Element/Helpers/PropertiesAccessor.cs
+++ b/Winium/Winium.StoreApps.InnerServer/Element/Helpers/PropertiesAccessor.cs
@@ -35,6 +35,7 @@
 
         public static bool TryGetDependencyProperty(FrameworkElement element, string propertyName, out object value)
         {
+            propertyName = string.Format("{0}Property", propertyName);
             value = null;
             var propertyInfo =
                 element.GetType()

--- a/Winium/Winium.StoreApps.InnerServer/Element/WiniumElement.cs
+++ b/Winium/Winium.StoreApps.InnerServer/Element/WiniumElement.cs
@@ -145,6 +145,15 @@
 
         public bool TryGetAutomationProperty(string automationPropertyName, out object value)
         {
+            const string Prefix = "AutomationProperties.";
+            value = null;
+            if (!automationPropertyName.StartsWith(Prefix))
+            {
+                return false;
+            }
+
+            automationPropertyName = automationPropertyName.Remove(0, Prefix.Length);
+
             return AutomationPropertiesAccessor.TryGetAutomationProperty(
                 this.Element, 
                 automationPropertyName, 


### PR DESCRIPTION
This breaks v1.5.0 GetElementAttribute  compatibility

To access Automation Properties the name of property:
 - must prefixed by `AutomationProperties.`
 - must not be suffixed by `Property`
 - examples:
  - `AutomationProperties.AutomationId`
  - `AutomationProperties.Name`

To access Dependency Properties the name of the property:
 - must not be suffixed by `Property`
 - examples:
  - `IsReadOnly`