### PR TITLE
Add path expansion for files capability

### DIFF
--- a/Winium/Winium.Mobile.Connectivity/Deployer.cs
+++ b/Winium/Winium.Mobile.Connectivity/Deployer.cs
@@ -113,7 +113,7 @@ namespace Winium.Mobile.Connectivity
                 .ReceiveFile(sourceDeviceFilePath, targetDesktopFilePath, true);
         }
 
-        public void SendFiles(Dictionary<string, string> files)
+        public void SendFiles(List<KeyValuePair<string, string>> files)
         {
             if (files == null || !files.Any())
             {
@@ -123,14 +123,8 @@ namespace Winium.Mobile.Connectivity
             var isolatedStore = this.RemoteApplication.GetIsolatedStore("Local");
             foreach (var file in files)
             {
-                var phoneDirectoryName = Path.GetDirectoryName(file.Value);
-                var phoneFileName = Path.GetFileName(file.Value);
-                if (string.IsNullOrEmpty(phoneFileName))
-                {
-                    phoneFileName = Path.GetFileName(file.Key);
-                }
-
-                isolatedStore.SendFile(file.Key, Path.Combine(phoneDirectoryName, phoneFileName), true);
+                Logger.Debug("Sending file \"{0}\" to \"{1}\"", file.Key, file.Value);
+                isolatedStore.SendFile(file.Key, file.Value, true);
             }
         }
 

--- a/Winium/Winium.Mobile.Connectivity/IDeployer.cs
+++ b/Winium/Winium.Mobile.Connectivity/IDeployer.cs
@@ -24,7 +24,7 @@ namespace Winium.Mobile.Connectivity
 
         void ReceiveFile(string isoStoreRoot, string sourceDeviceFilePath, string targetDesktopFilePath);
 
-        void SendFiles(Dictionary<string, string> files);
+        void SendFiles(List<KeyValuePair<string, string>> files);
 
         void Terminate();
 

--- a/Winium/Winium.StoreApps.Driver.Tests/FileListExpanderTests.cs
+++ b/Winium/Winium.StoreApps.Driver.Tests/FileListExpanderTests.cs
@@ -1,0 +1,88 @@
+﻿namespace Winium.StoreApps.Driver.Tests
+{
+    #region
+
+    using System.Collections.Generic;
+    using System.IO.Abstractions.TestingHelpers;
+    using System.Linq;
+
+    using NUnit.Framework;
+
+    using Winium.StoreApps.Driver.CommandHelpers;
+
+    #endregion
+
+    [TestFixture]
+    public class FileExpanderTests
+    {
+        #region Fields
+
+        private FilesCapabilityExpander expander;
+
+        #endregion
+
+        #region Public Methods and Operators
+
+        [SetUp]
+        public void BeforeTest()
+        {
+            var fileSystem =
+                new MockFileSystem(
+                    new Dictionary<string, MockFileData>
+                        {
+                            { @"c:\root.txt", new MockFileData(string.Empty) }, 
+                            { @"c:\demo\nested1.txt", new MockFileData(string.Empty) }, 
+                            { @"c:\demo\nested2.txt", new MockFileData(string.Empty) },
+                            { @"c:\demo\subfolder\file.txt", new MockFileData(string.Empty) },
+                        });
+
+            this.expander = new FilesCapabilityExpander(fileSystem);
+        }
+
+        [Test]
+        public void TestFileExpanderFileToDirectory()
+        {
+            var d = new Dictionary<string, string> { { @"c:\root.txt", "downloads/" } };
+            var rv = this.expander.ExpandFiles(d);
+            Assert.AreEqual("downloads\\root.txt", rv.First().Value);
+        }
+
+        [Test]
+        public void TestFileExpanderFileToFile()
+        {
+            var d = new Dictionary<string, string> { { @"c:\root.txt", "downloads/new.txt" } };
+            var rv = this.expander.ExpandFiles(d);
+            Assert.AreEqual("downloads\\new.txt", rv.First().Value);
+        }
+
+        [Test]
+        public void TestFileExpanderDirectoryToDirectory()
+        {
+            var d = new Dictionary<string, string> { { @"c:\demo/", "downloads" } };
+            var rv = this.expander.ExpandFiles(d);
+            var expected = new List<string>
+                               {
+                                   @"downloads\nested1.txt",
+                                   @"downloads\nested2.txt",
+                                   @"downloads\subfolder\file.txt",
+                               };
+            CollectionAssert.AreEqual(expected, rv.Select(x => x.Value));
+        }
+
+        [Test]
+        public void TestFileExpanderDirectoryToRootDirectory()
+        {
+            var d = new Dictionary<string, string> { { @"c:\demo/", string.Empty } };
+            var rv = this.expander.ExpandFiles(d);
+            var expected = new List<string>
+                               {
+                                   @"nested1.txt",
+                                   @"nested2.txt",
+                                   @"subfolder\file.txt",
+                               };
+            CollectionAssert.AreEqual(expected, rv.Select(x => x.Value));
+        }
+
+        #endregion
+    }
+}

--- a/Winium/Winium.StoreApps.Driver.Tests/Properties/AssemblyInfo.cs
+++ b/Winium/Winium.StoreApps.Driver.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Winium.StoreApps.Driver.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Winium.StoreApps.Driver.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("0c036ea5-8c76-4638-832d-9ced3a0ed57c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Winium/Winium.StoreApps.Driver.Tests/Winium.StoreApps.Driver.Tests.csproj
+++ b/Winium/Winium.StoreApps.Driver.Tests/Winium.StoreApps.Driver.Tests.csproj
@@ -1,0 +1,111 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{07168ED9-C12A-43F5-898F-84AB113A9441}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Winium.StoreApps.Driver.Tests</RootNamespace>
+    <AssemblyName>Winium.StoreApps.Driver.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.IO.Abstractions">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.120\lib\net40\System.IO.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Abstractions.TestingHelpers">
+      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.0.0.120\lib\net40\System.IO.Abstractions.TestingHelpers.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="FileListExpanderTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Winium.StoreApps.Driver\Winium.StoreApps.Driver.csproj">
+      <Project>{B6BE579B-B008-45B2-9740-12F0E6223661}</Project>
+      <Name>Winium.StoreApps.Driver</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Winium/Winium.StoreApps.Driver.Tests/packages.config
+++ b/Winium/Winium.StoreApps.Driver.Tests/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.4" targetFramework="net451" />
+  <package id="System.IO.Abstractions" version="2.0.0.120" targetFramework="net451" />
+  <package id="System.IO.Abstractions.TestingHelpers" version="2.0.0.120" targetFramework="net451" />
+</packages>

--- a/Winium/Winium.StoreApps.Driver/Automator/Automator.cs
+++ b/Winium/Winium.StoreApps.Driver/Automator/Automator.cs
@@ -7,6 +7,7 @@
     using System.Diagnostics;
     using System.Drawing;
     using System.IO;
+    using System.Linq;
     using System.Threading;
 
     using Newtonsoft.Json;
@@ -16,6 +17,7 @@
     using Winium.Mobile.Connectivity.Emulator;
     using Winium.StoreApps.Common;
     using Winium.StoreApps.Common.Exceptions;
+    using Winium.StoreApps.Driver.CommandHelpers;
     using Winium.StoreApps.Logging;
 
     #endregion
@@ -168,7 +170,8 @@
             else
             {
                 this.Deployer.Install(appPath, this.ActualCapabilities.Dependencies);
-                this.Deployer.SendFiles(this.ActualCapabilities.Files);
+                var expandedFiles = new FilesCapabilityExpander().ExpandFiles(this.ActualCapabilities.Files).ToList();
+                this.Deployer.SendFiles(expandedFiles);
             }
         }
 

--- a/Winium/Winium.StoreApps.Driver/CommandHelpers/FilesCapabilityExpander.cs
+++ b/Winium/Winium.StoreApps.Driver/CommandHelpers/FilesCapabilityExpander.cs
@@ -1,0 +1,114 @@
+﻿namespace Winium.StoreApps.Driver.CommandHelpers
+{
+    #region
+
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.IO.Abstractions;
+
+    #endregion
+
+    public class FilesCapabilityExpander
+    {
+        #region Fields
+
+        private readonly IFileSystem fileSystem;
+
+        #endregion
+
+        #region Constructors and Destructors
+
+        public FilesCapabilityExpander(IFileSystem fileSystem = null)
+        {
+            if (fileSystem == null)
+            {
+                fileSystem = new FileSystem();
+            }
+
+            this.fileSystem = fileSystem;
+        }
+
+        #endregion
+
+        #region Public Methods and Operators
+
+        public IEnumerable<KeyValuePair<string, string>> ExpandFiles(Dictionary<string, string> files)
+        {
+            foreach (var item in files)
+            {
+                var source = NormalizePathSeparators(item.Key);
+                var destination = NormalizePathSeparators(item.Value);
+                if (this.fileSystem.Directory.Exists(source))
+                {
+                    var directoryInfo = this.fileSystem.DirectoryInfo.FromDirectoryName(source);
+                    foreach (var expandedItem in this.ExpandDirectory(directoryInfo, destination))
+                    {
+                        yield return expandedItem;
+                    }
+                }
+                else if (this.fileSystem.File.Exists(item.Key))
+                {
+                    var fileInfo = this.fileSystem.FileInfo.FromFileName(source);
+                    var expanded = this.ExpandFile(fileInfo, destination);
+                    yield return expanded;
+                }
+                else
+                {
+                    throw new IOException(string.Format("No such file or directory {0}", item.Key));
+                }
+            }
+        }
+
+        #endregion
+
+        #region Methods
+
+        private static string MakeRelative(FileInfoBase file, DirectoryInfoBase referenceDirectory)
+        {
+            var referencePath = NormalizePathSeparators(referenceDirectory.FullName);
+            referencePath = referencePath.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+            var filePath = file.FullName;
+            var fileUri = new Uri(filePath);
+            var referenceUri = new Uri(referencePath);
+            var relativePath = referenceUri.MakeRelativeUri(fileUri).ToString();
+            return NormalizePathSeparators(relativePath);
+        }
+
+        private static string NormalizePathSeparators(string path)
+        {
+            return path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+        }
+
+        private IEnumerable<KeyValuePair<string, string>> ExpandDirectory(
+            DirectoryInfoBase directoryInfo, 
+            string phonePath)
+        {
+            foreach (var item in directoryInfo.GetFiles("*", SearchOption.AllDirectories))
+            {
+                var relativePath = MakeRelative(item, directoryInfo);
+                yield return
+                    new KeyValuePair<string, string>(
+                        item.FullName, 
+                        this.fileSystem.Path.Combine(phonePath, relativePath));
+            }
+        }
+
+        private KeyValuePair<string, string> ExpandFile(FileInfoBase fileInfo, string phonePath)
+        {
+            var phoneDirectoryName = this.fileSystem.Path.GetDirectoryName(phonePath);
+            var phoneFileName = this.fileSystem.Path.GetFileName(phonePath);
+
+            if (string.IsNullOrEmpty(phoneFileName))
+            {
+                phoneFileName = fileInfo.Name;
+            }
+
+            var fullName = this.fileSystem.Path.Combine(phoneDirectoryName, phoneFileName);
+            var expandedFile = new KeyValuePair<string, string>(fileInfo.FullName, fullName);
+            return expandedFile;
+        }
+
+        #endregion
+    }
+}

--- a/Winium/Winium.StoreApps.Driver/Winium.StoreApps.Driver.csproj
+++ b/Winium/Winium.StoreApps.Driver/Winium.StoreApps.Driver.csproj
@@ -46,6 +46,9 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Abstractions">
+      <HintPath>..\packages\System.IO.Abstractions.2.0.0.120\lib\net40\System.IO.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="Microsoft.CSharp" />
@@ -81,6 +84,7 @@
     <Compile Include="CommandExecutors\TouchScrollExecutor.cs" />
     <Compile Include="CommandExecutors\TouchSingleTapExecutor.cs" />
     <Compile Include="CommandHelpers\BuildInfo.cs" />
+    <Compile Include="CommandHelpers\FilesCapabilityExpander.cs" />
     <Compile Include="CommandHelpers\SendKeysHelper.cs" />
     <Compile Include="CommandLineOptions.cs" />
     <Compile Include="HttpRequest.cs" />

--- a/Winium/Winium.StoreApps.Driver/packages.config
+++ b/Winium/Winium.StoreApps.Driver/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="CommandLineParser" version="1.9.71" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+  <package id="System.IO.Abstractions" version="2.0.0.120" targetFramework="net451" />
 </packages>

--- a/Winium/Winium.sln
+++ b/Winium/Winium.sln
@@ -41,6 +41,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Winium.StoreApps.Logging", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Phone.Tools.Deploy.Patched", "Microsoft.Phone.Tools.Deploy.Patched\Microsoft.Phone.Tools.Deploy.Patched.csproj", "{13B4DF5C-E542-4A7A-8F00-929D423B522C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Winium.StoreApps.Driver.Tests", "Winium.StoreApps.Driver.Tests\Winium.StoreApps.Driver.Tests.csproj", "{07168ED9-C12A-43F5-898F-84AB113A9441}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		TestApp\TestApp.Shared\TestApp.Shared.projitems*{10a0b15d-ca68-4a4f-83bc-639a62b5ef1e}*SharedItemsImports = 4
@@ -93,6 +95,9 @@ Global
 		{13B4DF5C-E542-4A7A-8F00-929D423B522C}.Debug|Any CPU.Build.0 = Debug|x86
 		{13B4DF5C-E542-4A7A-8F00-929D423B522C}.Release|Any CPU.ActiveCfg = Release|x86
 		{13B4DF5C-E542-4A7A-8F00-929D423B522C}.Release|Any CPU.Build.0 = Release|x86
+		{07168ED9-C12A-43F5-898F-84AB113A9441}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{07168ED9-C12A-43F5-898F-84AB113A9441}.Debug|Any CPU.Build.0 = Debug|x86
+		{07168ED9-C12A-43F5-898F-84AB113A9441}.Release|Any CPU.ActiveCfg = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
`files` capability now support sending contents of directories, not only files

Usage examples:
```
"D:\\preinstalled\\": "",
"D:\\preinstalled\\": "downloads",
"D:\\preinstalled\\settings.xml": "data\\",
"D:\\preinstalled\\settings.xml": "data"
```

Fixes #125 