### PR TITLE
Fix PageSourceCommand failing to serialize nested classes

### DIFF
--- a/Winium/Winium.StoreApps.InnerServer.Tests/PageSourceCommandTests.cs
+++ b/Winium/Winium.StoreApps.InnerServer.Tests/PageSourceCommandTests.cs
@@ -1,0 +1,52 @@
+﻿namespace Winium.StoreApps.InnerServer.Tests
+{
+    #region
+
+    using System.Text;
+    using System.Xml;
+
+    using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+
+    using Windows.Data.Xml.Dom;
+    using Windows.UI.Xaml.Controls;
+
+    using Winium.StoreApps.InnerServer.Commands;
+    using Winium.StoreApps.InnerServer.Element;
+
+    #endregion
+
+    [TestClass]
+    public class PageSourceCommandTests
+    {
+        #region Public Methods and Operators
+
+        [TestMethod]
+        public void ShouldEncodeTagName()
+        {
+            UiDispatch.Invoke(
+                () =>
+                    {
+                        var winiumElement = new WiniumElement(new TestControl());
+
+                        var sb = new StringBuilder();
+                        using (var writer = XmlWriter.Create(sb))
+                        {
+                            PageSourceCommand.WriteElementToXml(writer, winiumElement);
+                        }
+
+                        var doc = new XmlDocument();
+                        doc.LoadXml(sb.ToString());
+                        var element = doc.DocumentElement;
+
+                        Assert.AreEqual(XmlConvert.EncodeLocalName(winiumElement.ClassName), element.LocalName);
+                        Assert.AreEqual(winiumElement.ClassName, element.GetAttribute("class_name"));
+                    }).Wait();
+        }
+
+        #endregion
+
+        public class TestControl : TextBox
+        {
+        }
+    }
+}

--- a/Winium/Winium.Storeapps.InnerServer.Tests/Winium.Storeapps.InnerServer.Tests.csproj
+++ b/Winium/Winium.Storeapps.InnerServer.Tests/Winium.Storeapps.InnerServer.Tests.csproj
@@ -74,6 +74,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GetElementAttributeCommandTests.cs" />
+    <Compile Include="PageSourceCommandTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UiDispatch.cs" />
     <Compile Include="PropertyAccessorsTests\DependencyPropertiesAccessorTests.cs" />


### PR DESCRIPTION
Class name for nested class follows "{parent}+{nested}" pattern.
The plus sign is invalid character for xml tag name. To prevent page source command from throwing we encode all xml tag names and add class_name attribute with original unencoded class name to each tag.

Fixes #135 